### PR TITLE
use tls

### DIFF
--- a/nodes/locales/en-US/server.json
+++ b/nodes/locales/en-US/server.json
@@ -5,7 +5,9 @@
         "host": "Host",
         "mqtt_port": "MQTT Port",
         "mqtt_username": "MQTT Username",
-        "mqtt_password": "MQTT Password"
+        "mqtt_password": "MQTT Password",
+        "use-tls": "Use TLS",
+        "tls-config":"TLS configuration"
     },
     "placeholder": {
         "name": "Name"

--- a/nodes/server.html
+++ b/nodes/server.html
@@ -26,6 +26,13 @@
         <label for="node-config-input-mqtt_password" class="l-width"><i class="fa fa-lock"></i> <span data-i18n="label.mqtt_password"></span></label>
         <input type="password" id="node-config-input-mqtt_password" autocomplete="new-password">
     </div>
+    <div class="form-row">
+        <input type="checkbox" id="node-config-input-usetls" style="display: inline-block; width: auto; vertical-align: top;">
+        <label for="node-config-input-usetls" style="width: auto" data-i18n="label.use-tls"></label>
+        <div id="node-config-row-tls" >
+            <label style="width: auto; margin-left: 20px; margin-right: 10px;" for="node-config-input-tls"><span data-i18n="label.tls-config"></span></label><input style="width: 300px;" type="text" id="node-config-input-tls">
+        </div>
+    </div>
     <div class="form-tips" data-i18n="[html]tip.deploy"></div>
 
 </script>
@@ -54,6 +61,8 @@
                 value: null,
                 required: false
             },
+            tls: {type:"tls-config",required: false},
+            usetls: {value: false},
             base_topic: {
                 value: 'zigbee2mqtt',
                 required: true

--- a/nodes/server.js
+++ b/nodes/server.js
@@ -45,7 +45,16 @@ module.exports = function (RED) {
                 password: node.config.mqtt_password||null,
                 clientId:"NodeRed-"+node.id+(clientId?"-"+clientId:"")
             };
-            return mqtt.connect('mqtt://' + node.config.host, options);
+
+            let baseUrl='mqtt://';
+
+            var tlsNode = RED.nodes.getNode(node.config.tls);
+            if (tlsNode) {
+                tlsNode.addTLSOptions(options);
+                baseUrl='mqtts://';
+            }
+
+            return mqtt.connect( baseUrl + node.config.host, options);
         }
 
 


### PR DESCRIPTION
I used alsmost  the same code from the original node-red mqtt node to enable tls support : https://github.com/node-red/node-red/blob/master/packages/node_modules/%40node-red/nodes/core/network/10-mqtt.html.

I tested  with my own mosquitto server with self generated certificates, when you use self generated certificates you must unchecked the  Verify server certificate option : 

![image](https://user-images.githubusercontent.com/1395600/88487492-cae7a480-cf85-11ea-9736-a6ba850e734a.png)
![image](https://user-images.githubusercontent.com/1395600/88487504-e783dc80-cf85-11ea-968f-6fcf02a41e97.png)

