### PR TITLE
Add Switch support to payload2homekit

### DIFF
--- a/lib/Zigbee2mqttHelper.js
+++ b/lib/Zigbee2mqttHelper.js
@@ -265,6 +265,12 @@ class Zigbee2mqttHelper {
             };
         }
 
+        //Switch
+        if ("state" in payload && (payload.state == "ON" || payload.state == "OFF")) {
+            msg["Switch"] = {
+                "On":payload.state == "ON"
+            };
+        }
 
 
         return msg;


### PR DESCRIPTION
This PR is to add support for Homekit Switch.

Currently standard light switch field is only state (with values ON/OFF).
Because of that this node is not showing Paylod output type in Homekit format.
![image](https://user-images.githubusercontent.com/2881159/95360650-f6fb9c00-08cb-11eb-9b16-ab80aceee34c.png)

