### PR TITLE
Add brightness_step option to output block

### DIFF
--- a/nodes/locales/en-US/out.json
+++ b/nodes/locales/en-US/out.json
@@ -24,6 +24,7 @@
         "options": "Options:",
         "command_homekit": "This is experimental feature, works only with Lightbulb, Lock Services for now. ",
         "command_brightness_move": "Instead of setting a brightness by value, you can also move it and stop it after a certain time. Example: -5 payload will start moving the brightness down at 5 units per second.",
+        "command_brightness_step": "Instead of setting a brightness by value, you can also change current value up or down.",
         "option_transition": "Specifies the number of seconds the transition to this state takes. Doesn't work for brightness=0, state=toggle."
     }
 }

--- a/nodes/out.html
+++ b/nodes/out.html
@@ -49,6 +49,11 @@
         <strong><span data-i18n="help.description"></span></strong><br>
         <span data-i18n="help.command_brightness_move"></span>
     </div>
+    <!--brightness_step-->
+    <div class="form-tips help_block help_block__z2m_cmd_brightness_step">
+        <strong><span data-i18n="help.description"></span></strong><br>
+        <span data-i18n="help.command_brightness_step"></span>
+    </div>
     <!--transition-->
     <div class="help_block help_block__z2m_cmd_brightness help_block__z2m_cmd_state help_block__z2m_cmd_color_temp help_block__z2m_cmd_hue help_block__z2m_cmd_saturation">
         <strong><span data-i18n="help.options"></span></strong><br>
@@ -128,6 +133,7 @@
                     {'value':'state', 'label':'State (on|off|toggle)'},
                     {'value':'brightness', 'label':'Brightness (0..255)'},
                     {'value':'brightness_move', 'label':'Brightness Move (-255...255|stop)'},
+                    {'value':'brightness_step', 'label':'Brightness Step (-255...255)'},
                     {'value':'color', 'label':'Color: {}'},
                     {'value':'color_rgb', 'label':'Color: r,g,b'},
                     {'value':'color_hex', 'label':'Color: #hex'},

--- a/nodes/out.js
+++ b/nodes/out.js
@@ -133,6 +133,7 @@ module.exports = function(RED) {
                                         break;
 
                                     case 'brightness_move':
+                                    case 'brightness_step':
                                     case 'alert':
                                     default: {
                                         break;


### PR DESCRIPTION
This adds `brightness_step` command that is currently missing.

Command is described here: [zigbee2mqtt/IKEA L1527](https://www.zigbee2mqtt.io/devices/L1527.html#movingstepping)

Is there any reason why it wasn't added and similar command `brigthness_move` was?
