### PR TITLE
Add configurable transition for HK cmd and resolve issues with help blocks.

### DIFF
--- a/nodes/out.html
+++ b/nodes/out.html
@@ -55,7 +55,7 @@
         <span data-i18n="help.command_brightness_step"></span>
     </div>
     <!--transition-->
-    <div class="help_block help_block__z2m_cmd_brightness help_block__z2m_cmd_state help_block__z2m_cmd_color_temp help_block__z2m_cmd_hue help_block__z2m_cmd_saturation">
+    <div class="help_block help_block__z2m_cmd_brightness help_block__z2m_cmd_state help_block__z2m_cmd_color_temp help_block__z2m_cmd_hue help_block__z2m_cmd_saturation help_block__homekit_homekit">
         <strong><span data-i18n="help.options"></span></strong><br>
 
         <div class="form-row">
@@ -101,7 +101,7 @@
                 value: 'msg',
             },
             transition: {
-                value: 0,
+                value: "0",
                 required: false
             },
         },

--- a/nodes/out.html
+++ b/nodes/out.html
@@ -210,8 +210,6 @@
                 } else {
                     $('#node-input-payload').closest('.form-row').show();
                 }
-
-                showHelpBlock();
             });
 
 
@@ -237,7 +235,6 @@
                 var $deviceInput = $('#node-input-device_id');
 
                 z2m_getItemList(node.device_id, '#node-input-device_id', {allowEmpty:false});
-                showHelpBlock();
                 // $deviceInput.on('change', function(){
                 //     z2m_getItemStateList(0, '#node-input-state');
                 // });
@@ -245,6 +242,9 @@
                 //     z2m_getItemStateList(node.state, '#node-input-state');
                 // },100);
             }, 100); //we need small timeout, too fire change event for server select
+
+            let previousCommand = ''
+            let previousCommandType = ''
 
             function showHelpBlock() {
                 var command = $('#node-input-command').val(); //state
@@ -254,10 +254,24 @@
                 if (command == '{}') command = 'json';
                 if (commandType == 'str') command = 'custom';
 
-                $('.help_block').hide();
-                $('.help_block__'+commandType+'_'+command).show();
+                if (previousCommand !== command || previousCommandType !== commandType) {
+                    previousCommand = command
+                    previousCommandType = commandType
+
+                    $('.help_block').hide(() => {
+                        $('.help_block__'+commandType+'_'+command).show();
+                    });
+                }
             }
 
+            showHelpBlock();
+
+            $('#node-input-command').on('change', function(type, value) {
+                showHelpBlock();
+            });
+            $('#node-input-commandType').on('change', function(type, value) {
+                showHelpBlock();
+            });
         }
     });
 </script>

--- a/nodes/out.js
+++ b/nodes/out.js
@@ -78,6 +78,8 @@ module.exports = function(RED) {
                             }
                         }
 
+                        // Default 0. Might be set to empty which will resolve as NaN.
+                        const transition = parseInt(node.config.transition)
 
                         var command;
                         switch (node.config.commandType) {
@@ -127,8 +129,8 @@ module.exports = function(RED) {
                                         break;
 
                                     case 'color_temp':
-                                        if ("transition" in node.config && (node.config.transition).length > 0) {
-                                            options['transition'] = parseInt(node.config.transition);
+                                        if (!isNaN(transition)) {
+                                            options['transition'] = transition;
                                         }
                                         break;
 
@@ -150,7 +152,11 @@ module.exports = function(RED) {
                                 }
 
                                 payload = node.formatHomeKit(message, device);
-                                options['transition'] = 0; //doesnt work well
+
+                                if (!isNaN(transition)) {
+                                    options['transition'] = transition;
+                                }
+
                                 break;
 
                             case 'json':


### PR DESCRIPTION
Two things I did in this PR.

First was allowing user to set (change) transition value being sent to z2m for homekit commands.
Previously it was hardcoded `transition: 0` which in my case was causing a lot of issues on z2m side (`No converter available for 'transition' (0) zigbee2mqtt`)
Not it is allowed to just remove default 0 (zero) and leave it blank which will prevent `transition` from being added.

Second, I have noticed that in some combinations of UI steps, help blocks were disappearing.
Now I am ensuring hide() is not called again when command and commandType are not changed (jQuery change event can be called for the same value which was mess).