### PR TITLE
Add warning for trying to get state before it changed

### DIFF
--- a/nodes/server.js
+++ b/nodes/server.js
@@ -517,6 +517,9 @@ module.exports = function(RED) {
 
             if (item) {
                 payload_all = item.current_values;
+                if (payload_all == null) {
+                    node.warn('You need to turn on the "retain" option for the device in Zigbee2MQTT to be able to read it before a state change.')
+                }
             } else {
                 node.status({
                     fill: "red",


### PR DESCRIPTION
I was trying to make an automation that reads if a lamp is turned on and then sets the brightness if yes (because setting the brightness also turns it on) but since I just deployed my flows, there was no last state that I could get. After some googling, I found out that you need to turn on retain for the device in Zigbee2MQTT to solve this. Hopefully this will save others from trying to figure out why their get node doesn't work.