### PR TITLE
Fix log level: warning

### DIFF
--- a/nodes/bridge.html
+++ b/nodes/bridge.html
@@ -55,7 +55,7 @@
                     <label for="log_level_info_btn" class="l-width"><i class="fa fa-commenting-o"></i> <span data-i18n="label.log_level"></span></label>
                     <button style="width: 17%" class="red-ui-button log_level_btn" data-level="info" id="log_level_info_btn"><span data-i18n="label.log_level_info"></span></button>
                     <button style="width: 17%" class="red-ui-button log_level_btn" data-level="debug" id="log_level_debug_btn"><span data-i18n="label.log_level_debug"></span></button>
-                    <button style="width: 17%" class="red-ui-button log_level_btn" data-level="warn" id="log_level_warn_btn"><span data-i18n="label.log_level_warn"></span></button>
+                    <button style="width: 17%" class="red-ui-button log_level_btn" data-level="warning" id="log_level_warning_btn"><span data-i18n="label.log_level_warning"></span></button>
                     <button style="width: 17%" class="red-ui-button log_level_btn" data-level="error" id="log_level_error_btn"><span data-i18n="label.log_level_error"></span></button>
                 </div>
                 <div class="form-row">

--- a/nodes/locales/en-US/bridge.json
+++ b/nodes/locales/en-US/bridge.json
@@ -8,7 +8,7 @@
         "log_level": "Log Level",
         "log_level_info": "info",
         "log_level_debug": "debug",
-        "log_level_warn": "warn",
+        "log_level_warning": "warning",
         "log_level_error": "error",
         "version": "Version",
         "restart_required": "Restart required",

--- a/nodes/locales/sk-SK/bridge.json
+++ b/nodes/locales/sk-SK/bridge.json
@@ -8,7 +8,7 @@
         "log_level": "Úroveň záznamu",
         "log_level_info": "info",
         "log_level_debug": "debug",
-        "log_level_warn": "upozornenie",
+        "log_level_warning": "upozornenie",
         "log_level_error": "chyba",
         "version": "Verzia",
         "restart_required": "Vyžadovaný reštart",

--- a/nodes/server.js
+++ b/nodes/server.js
@@ -184,7 +184,7 @@ module.exports = function(RED) {
 
         setLogLevel(val) {
             let node = this;
-            if (['info', 'debug', 'warn', 'error'].indexOf(val) < 0) val = 'info';
+            if (['info', 'debug', 'warning', 'error'].indexOf(val) < 0) val = 'info';
             let payload = {
                 'options': {
                     'advanced': {


### PR DESCRIPTION
This commit renames "log level: warn" to "log level: warning" to adopt to changes made in Zigbee2MQTT in May 2024, see https://github.com/Koenkk/zigbee2mqtt.io/commit/493bc4efc5ff176703e39216fb0572839552e85a and https://github.com/Koenkk/zigbee2mqtt/issues/22706. 

Thanks!